### PR TITLE
Adds more clear filename camelCasifying

### DIFF
--- a/lib/readsalot.js
+++ b/lib/readsalot.js
@@ -1,15 +1,26 @@
 var fs = require('fs');
+var path = require('path');
 
 function load(directory) {
   var files = {};
-  var path = process.cwd() + directory;
+  var dirPath = process.cwd() + directory;
 
-  fs.readdirSync(path).forEach(function(file) {
-    if (fs.statSync(path + '/' + file).isDirectory()) return;
-    var filename = file.split('.')[0].replace(/((\-|\_)[a-z0-9])/g, function(param) {
-      return param.toUpperCase().replace(param[0],'');
-    });
-    files[filename] = fs.readFileSync(path + '/' + file, 'utf8');
+  fs.readdirSync(dirPath).forEach(function(file) {
+    if (fs.statSync(dirPath + '/' + file).isDirectory()) return;
+
+    var filename = path.basename(file, path.extname(file))
+      .replace(/[-_\ ]/g, '-')  // Replace all the word separators with `-`
+      .split('-')               // split the words into an array
+      .map(function (word, i) { // camelCasify
+        if (i === 0) { // First word we don't capitalize
+          return word.toLowerCase();
+        } else {
+          return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
+        }
+      })
+      .join(''); // Come back together
+
+    files[filename] = fs.readFileSync(dirPath + '/' + file, 'utf8');
   });
 
   return files;


### PR DESCRIPTION
The previous way to camelCaseify a filename was broken. Before it would work if you have a filename like: `get-all-customers.sql` and it would add a key `getAllCustomers`. I ran into some files that were named like `get-All-Customers.sql` (I know, that was bad anyway...) but I got back `get-All-Customers`. This way makes it a bit more clear as to how it's camelcaseifying the filename. If you don't like it, let me know.
