### PR TITLE
Entire first word shouldn't be lowercased

### DIFF
--- a/lib/readsalot.js
+++ b/lib/readsalot.js
@@ -13,7 +13,7 @@ function load(directory) {
       .split('-')               // split the words into an array
       .map(function (word, i) { // camelCasify
         if (i === 0) { // First word we don't capitalize
-          return word.toLowerCase();
+          return word.charAt(0).toLowerCase() + word.substr(1);
         } else {
           return word.charAt(0).toUpperCase() + word.substr(1).toLowerCase();
         }


### PR DESCRIPTION
If a filename was already camelCased, this line would lowercase the entire thing (as there weren't any word separators)
Existing Functionality should stay the same
(i.e. "My-Cool Query.txt" => "myCoolQuery")
(i.e. "myCoolQuery.txt" => "myCoolQuery")
